### PR TITLE
correct overlay and define macro for disk name to work on zephyr 4.0.0

### DIFF
--- a/boards/blackpill_f411ce.overlay
+++ b/boards/blackpill_f411ce.overlay
@@ -19,6 +19,7 @@
                 status = "okay";
                 mmc {
                     compatible = "zephyr,sdmmc-disk";
+                    disk-name = "SD";
                     status = "okay";
                 };
                 spi-max-frequency = <24000000>;

--- a/src/main.c
+++ b/src/main.c
@@ -102,6 +102,15 @@ static struct fs_mount_t __mp = {
 
 struct fs_mount_t *mountpoint = &__mp;
 
+#if defined(CONFIG_DISK_DRIVER_SDMMC)
+  #define CONFIG_SDMMC_VOLUME_NAME "SD"
+#elif defined(CONFIG_DISK_DRIVER_MMC)
+  #define CONFIG_SDMMC_VOLUME_NAME "SD2"
+#else
+  #error "No disk device defined, is your board supported?"
+#endif
+
+
 static const char *disk_mount_pt = "/" CONFIG_SDMMC_VOLUME_NAME ":";
 static const char *disk_pdrv = CONFIG_SDMMC_VOLUME_NAME;
 


### PR DESCRIPTION
From [littlefs example](https://github.com/zephyrproject-rtos/zephyr/blob/main/samples/subsys/fs/littlefs/src/main.c) and [zephyr,sdmmc-disk.yaml](https://github.com/zephyrproject-rtos/zephyr/blob/main/dts/bindings/sd/zephyr%2Csdmmc-disk.yaml) for zephyr v4.0.0