### PR TITLE
change: Add blackpill overlay license header

### DIFF
--- a/boards/blackpill_f411ce.overlay
+++ b/boards/blackpill_f411ce.overlay
@@ -1,3 +1,20 @@
+/*
+ * This file is part of the efc project <https://github.com/eurus-project/efc/>.
+ * Copyright (c) 2024 The efc developers.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
 / {
 	chosen {
 		zephyr,console = &cdc_acm_uart;


### PR DESCRIPTION
This adds the blackpill overlay license header which was forgotten previously.