### PR TITLE
ci: add format check stage to ci pipeline

### DIFF
--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -1,0 +1,16 @@
+name: clang-format check
+
+on: 
+  push:
+  
+jobs:
+  formatting-check:
+    name: format check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Run clang-format style check for C/C++ source files.
+      uses: jidicula/clang-format-action@v4.14.0
+      with:
+        clang-format-version: '18'
+        check-path: 'src'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-clang-format
-  rev: v18.1.8
+  rev: v18.1.3
   hooks:
   - id: clang-format


### PR DESCRIPTION

The CI pipeline now includes a format check stage, implemented using GitHub Actions.

This stage uses clang-format (_v18.1.3_) to check that code is formatted regularly. The format is specified in the `.clang-format` file. 