### PR TITLE
added venv_python path for windows platform

### DIFF
--- a/src/logging/ulog/CMakeLists.txt
+++ b/src/logging/ulog/CMakeLists.txt
@@ -21,8 +21,13 @@ cmake_minimum_required(VERSION 3.20.0)
 set(YAML_DIR ${CMAKE_SOURCE_DIR}/messages/ulog)
 set(GENERATED_DIR ${CMAKE_BINARY_DIR}/ulog/generated)
 set(GENERATOR_SCRIPT ${CMAKE_SOURCE_DIR}/tools/ulog_gen.py)
-set(VENV_PYTHON ${CMAKE_SOURCE_DIR}/python_venv/bin/python)
 
+if(CMAKE_HOST_WIN32)
+	set(VENV_PYTHON ${CMAKE_SOURCE_DIR}/python_venv/Scripts/python)
+else()
+	set(VENV_PYTHON ${CMAKE_SOURCE_DIR}/python_venv/bin/python)
+endif()
+	
 file(MAKE_DIRECTORY ${GENERATED_DIR})
 
 file(GLOB YAML_FILES ${YAML_DIR}/*.yaml)


### PR DESCRIPTION
Python virtual environments on the Windows platform have a different structure than on other platforms. The bin folder does not exist, and python.exe is located in the Scripts folder. Because of this, the path to Python in src/logging/ulog/CMakeLists.txt must be specified differently if CMake detects the Windows platform.