### PR TITLE
Fix transport layer name for openocd_stlink.cfg files

### DIFF
--- a/openocd_stm32f1_stlink.cfg
+++ b/openocd_stm32f1_stlink.cfg
@@ -1,6 +1,6 @@
 source [find interface/stlink.cfg]
 
-transport select hla_swd # When swa is placed here, errors occure.
+transport select hla_swd
 
 source [find target/stm32f1x.cfg]
 

--- a/openocd_stm32f4_stlink.cfg
+++ b/openocd_stm32f4_stlink.cfg
@@ -1,6 +1,6 @@
 source [find interface/stlink.cfg]
 
-transport select swd # If some errors occure on this line, change swd to hla_swd
+transport select hla_swd
 
 source [find target/stm32f4x.cfg]
 

--- a/openocd_stm32h5_stlink.cfg
+++ b/openocd_stm32h5_stlink.cfg
@@ -1,6 +1,6 @@
 source [find interface/stlink-v2.cfg]
 
-transport select swd # If some errors occure on this line, change swd to hla_swd 
+transport select hla_swd 
 
 source [find target/stm32h5x.cfg]
 


### PR DESCRIPTION
The line "transport select <transport_layer>" in case of stlink openocd config files, must have hla_swd set as a transport_layer. When transport_layer is set to swd, errors occur. On the other side, for openocd_jlink.cfg  files transport_layer can be swd without any problem. 