### PR TITLE
Replace deprecated stlink_v2.cfg file with relevant stlink.cfg in openocd_stm32h5_stlink.cfg file

### DIFF
--- a/openocd_stm32h5_stlink.cfg
+++ b/openocd_stm32h5_stlink.cfg
@@ -1,4 +1,4 @@
-source [find interface/stlink-v2.cfg]
+source [find interface/stlink.cfg]
 
 transport select hla_swd 
 


### PR DESCRIPTION
The use of stlink_v2.cfg is deprecated, use stlink.cfg in openocd_stm32h5_stlink.cfg