### PR TITLE
change(tests): setup PoC infrastructure for hardware tests

### DIFF
--- a/tests/hardware/blinky/CMakeLists.txt
+++ b/tests/hardware/blinky/CMakeLists.txt
@@ -17,28 +17,8 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
-project(efc
-    VERSION 0.1
-    LANGUAGES C
+message("Got into blinky")
+target_sources(app
+PRIVATE
+main.c
 )
-
-
-if(NOT DEFINED EFC_TEST_NAME)
-
-    add_subdirectory(src/logging/ulog)
-
-    target_sources(app
-    PRIVATE
-    src/main.c
-    )
-
-    target_link_libraries(app
-    PRIVATE
-        ulog
-    )
-
-else()
-    file(GLOB_RECURSE FOUND_TEST_DIR LIST_DIRECTORIES true ${CMAKE_SOURCE_DIR}/tests/*/${EFC_TEST_NAME})
-    add_subdirectory(${FOUND_TEST_DIR}/)
-endif()

--- a/tests/hardware/blinky/main.c
+++ b/tests/hardware/blinky/main.c
@@ -1,0 +1,85 @@
+/*
+ * This file is part of the efc project <https://github.com/eurus-project/efc/>.
+ * Copyright (c) 2024 The efc developers.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/usb/usb_device.h>
+
+LOG_MODULE_REGISTER(main);
+
+// This LED simply blinks at an interval, indicating visually that the firmware
+// is running If anything causes the whole firmware to abort, it will be
+// apparent without looking at log output or hooking up a debugger.
+static const struct gpio_dt_spec fw_running_led =
+    GPIO_DT_SPEC_GET(DT_ALIAS(led0), gpios);
+
+#if defined(CONFIG_USB_DEVICE_STACK_NEXT)
+static struct usbd_context *sample_usbd;
+
+static int enable_usb_device_next(void) {
+    int err;
+
+    sample_usbd = sample_usbd_init_device(NULL);
+    if (sample_usbd == NULL) {
+        return -ENODEV;
+    }
+
+    err = usbd_enable(sample_usbd);
+    if (err) {
+        return err;
+    }
+
+    return 0;
+}
+#endif /* defined(CONFIG_USB_DEVICE_STACK_NEXT) */
+
+int main(void) {
+    if (DT_NODE_HAS_COMPAT(DT_CHOSEN(zephyr_console), zephyr_cdc_acm_uart)) {
+#if defined(CONFIG_USB_DEVICE_STACK_NEXT)
+        if (enable_usb_device_next()) {
+            return 0;
+        }
+#else
+        if (usb_enable(NULL)) {
+            return 0;
+        }
+#endif
+    }
+
+    if (!gpio_is_ready_dt(&fw_running_led)) {
+        LOG_ERR("The firmware running LED is not ready");
+        return 0;
+    }
+
+    int ret;
+    ret = gpio_pin_configure_dt(&fw_running_led, GPIO_OUTPUT_ACTIVE);
+    if (ret < 0) {
+        LOG_ERR("Could not configure the firmware running LED as output");
+        return 0;
+    }
+
+    while (1) {
+        ret = gpio_pin_toggle_dt(&fw_running_led);
+        if (ret < 0) {
+            LOG_ERR("Could not toggle the firmware running LED");
+            return 0;
+        }
+
+        k_msleep(1000);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Simple blinky test along with some CMake changes to allow west to build both the test and the main app (but not simultaneously).
Test can be run with:

`west build -b blackpill_f411ce -p -- -DEFC_TEST_NAME=blinky`