### PR TITLE
ci: fix ci build stage by adding apt update & upgade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,11 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Install required packages
         run: |
+          sudo apt update && sudo apt upgrade
           sudo apt install --no-install-recommends -y git cmake ninja-build gperf \
             ccache dfu-util device-tree-compiler wget \
             python3-dev python3-pip python3-setuptools python3-tk python3-wheel xz-utils file \
@@ -17,37 +18,32 @@ jobs:
       - name: Create a virtual environment for Zephyr and intall west
         run: |   
           python3 -m venv $GITHUB_WORKSPACE/zephyrproject/.venv
-          source $GITHUB_WORKSPACE/zephyrproject/.venv/bin/activate
-          pip install west
+          $GITHUB_WORKSPACE/zephyrproject/.venv/bin/pip install west
 
       - name: Get Zephyr source code
         run: |
-          source $GITHUB_WORKSPACE/zephyrproject/.venv/bin/activate
-          west init -m https://github.com/eurus-project/zephyr $GITHUB_WORKSPACE/zephyrproject/
+          $GITHUB_WORKSPACE/zephyrproject/.venv/bin/west init -m https://github.com/eurus-project/zephyr \
+            $GITHUB_WORKSPACE/zephyrproject/
 
       - name: Update Zephyr Workspace
         run: |
-          source $GITHUB_WORKSPACE/zephyrproject/.venv/bin/activate
           cd $GITHUB_WORKSPACE/zephyrproject/
-          west update
+          $GITHUB_WORKSPACE/zephyrproject/.venv/bin/west update
           
       - name: Export Zephyr CMake Package
         run: |
-          source $GITHUB_WORKSPACE/zephyrproject/.venv/bin/activate
           cd $GITHUB_WORKSPACE/zephyrproject/
-          west zephyr-export
+          $GITHUB_WORKSPACE/zephyrproject/.venv/bin/west zephyr-export
 
       - name: Install Python dependencies
         run: |
-          source $GITHUB_WORKSPACE/zephyrproject/.venv/bin/activate
           cd $GITHUB_WORKSPACE/zephyrproject/
-          west packages pip --install
+          $GITHUB_WORKSPACE/zephyrproject/.venv/bin/west packages pip --install
 
       - name: Install Zephyr SDK
         run: |
-          source $GITHUB_WORKSPACE/zephyrproject/.venv/bin/activate
           cd $GITHUB_WORKSPACE/zephyrproject/
-          west sdk install
+          $GITHUB_WORKSPACE/zephyrproject/.venv/bin/west sdk install
 
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -62,6 +58,5 @@ jobs:
 
       - name: Build project
         run: |
-          source $GITHUB_WORKSPACE/zephyrproject/.venv/bin/activate
           cd $GITHUB_WORKSPACE/zephyrproject/${{ github.repository }}
-          west build -b blackpill_f411ce
+          $GITHUB_WORKSPACE/zephyrproject/.venv/bin/west build -b blackpill_f411ce

--- a/.github/workflows/pre-commit-checks.yml
+++ b/.github/workflows/pre-commit-checks.yml
@@ -6,10 +6,11 @@ on:
 jobs:
   formatting-check:
     name: format check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Install requirements
         run: |
+          sudo apt update && sudo apt upgrade
           sudo apt install --no-install-recommends -y git python3-venv
 
       - name: Install pre-commit


### PR DESCRIPTION
Build stage of GH actions CI pipeline was missing packages updating, which caused stage breakage. This PR also includes removing of unnecessary activation of python virtual environments and fixing ubuntu to 24.04 version.