### PR TITLE
Fix/workspace app fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
-set(EFC_SOURCE_DIR ${CMAKE_SOURCE_DIR}/../)
+set(EFC_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 if(CMAKE_HOST_WIN32)
 	set(VENV_PYTHON ${EFC_SOURCE_DIR}/python_venv/Scripts/python)
 else()

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This project is built as a [workspace](https://docs.zephyrproject.org/4.0.0/deve
 
 1. Install the required dependencies as desribed in the [Zephyr Getting Started#Install Dependencies](https://docs.zephyrproject.org/4.0.0/develop/getting_started/index.html#install-dependencies).
 2. Clone the efc repository into an empty directory (e.g. `~/eurus/efc/`). Container directory (`~/eurus/` workspace) will contain Zephyr and additional modules.
+>Note: Clone the repository with --recurse-submodules flag to recursively update git submodules.
+
 3. Create a new Python virtual environment in the workspace, install west and configure zephyr-related dependencies.
 ```bash
 cd ~/eurus
@@ -33,6 +35,9 @@ deactivate
 
 Use `west` or CMake to build for one of the supported boards:
 ```bash
+cd ~/eurus
+source .venv/bin/activate
+cd efc
 west build -b blackpill_f411ce app
 ```
 


### PR DESCRIPTION
Couple of fixes for issues that were brought in when migrating to workspace app:
- Update missing info in README
- Switch to CMAKE_CURRENT_SOURCE_DIR in efc libs to make the build application-independent