### PR TITLE
Update years in the licence statements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) 2024 The efc developers.
+# Copyright (c) (2024 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) 2024 The efc developers.
+# Copyright (c) (2024 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/app/boards/blackpill_f411ce.overlay
+++ b/app/boards/blackpill_f411ce.overlay
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 The efc developers.
+ * Copyright (c) (2024 - Present) The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/prj.conf
+++ b/app/prj.conf
@@ -1,6 +1,6 @@
 # 
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) 2024 The efc developers.
+# Copyright (c) (2024 - Present), The efc developers.
 # 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/app/src/logger.c
+++ b/app/src/logger.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/logger.h
+++ b/app/src/logger.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) (2024 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/radio_receiver.c
+++ b/app/src/radio_receiver.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/radio_receiver.h
+++ b/app/src/radio_receiver.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_packer.c
+++ b/app/src/telemetry_packer.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_packer.h
+++ b/app/src/telemetry_packer.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_sender.c
+++ b/app/src/telemetry_sender.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_sender.h
+++ b/app/src/telemetry_sender.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/types.h
+++ b/app/src/types.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) 2024 The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/logging/CMakeLists.txt
+++ b/libs/logging/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) 2024 The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/logging/ulog/CMakeLists.txt
+++ b/libs/logging/ulog/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) 2024 The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/logging/ulog/ulog.c
+++ b/libs/logging/ulog/ulog.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/logging/ulog/ulog.h
+++ b/libs/logging/ulog/ulog.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/telemetry/CMakeLists.txt
+++ b/libs/telemetry/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) 2024 The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/telemetry/mavlink/CMakeLists.txt
+++ b/libs/telemetry/mavlink/CMakeLists.txt
@@ -1,6 +1,6 @@
 #
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) 2024 The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/telemetry/mavlink/mavlink.c
+++ b/libs/telemetry/mavlink/mavlink.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024-2025 The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
In order to resolve the issue opened by @lkijanovic : [(https://github.com/eurus-project/efc/issues/46)] This PR presents my proposal for a solution. The idea is to put a date in form (**year** - Present), where  **year** represents the year when file has been created. The word **Present** would serve as a placeholder for a year when some stable version of this project would be published. Please note that this is just my proposal, and that I am glad to hear another ideas. 