### PR TITLE
[DRAFT] ci: add license header checks stage to GH actions

### DIFF
--- a/.github/license-checks/config.json
+++ b/.github/license-checks/config.json
@@ -1,0 +1,23 @@
+[
+    {
+        "include": [
+            "app/src/*.c",
+            "app/src/*.h",
+            "libs/logging/ulog/*.c",
+            "libs/logging/ulog/*.h",
+            "libs/telemetry/mavlink/*.c"
+        ],
+        "license": "./.github/license-checks/license-header-cc.txt"
+    },
+    {
+        "include": [
+            "CMakeLists.txt",
+            "app/CMakeLists.txt",
+            "libs/logging/CMakeLists.txt",
+            "libs/logging/ulog/CMakeLists.txt",
+            "libs/telemetry/CMakeLists.txt",
+            "libs/telemetry/mavlink/CMakeLists.txt"
+        ],
+        "license": "./.github/license-checks/license-header-cmake.txt"
+    }
+]

--- a/.github/license-checks/license-header-cc.txt
+++ b/.github/license-checks/license-header-cc.txt
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 The efc developers.
+ * Copyright (c) %year% The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -14,18 +14,3 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
-
-#include <stdint.h>
-
-struct imu_6dof_data {
-    uint64_t timestamp_us;
-    float temperature_degc;
-    float accel_mps2[3];
-    float gyro_radps[3];
-};
-
-struct baro_data {
-    uint64_t timestamp_us;
-    float temperature_degc;
-    float pressure_kpa;
-};

--- a/.github/license-checks/license-header-cmake.txt
+++ b/.github/license-checks/license-header-cmake.txt
@@ -1,0 +1,16 @@
+#
+# This file is part of the efc project <https://github.com/eurus-project/efc/>.
+# Copyright (c) %year% The efc developers.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, version 3.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+#

--- a/.github/workflows/license-checks.yml
+++ b/.github/workflows/license-checks.yml
@@ -1,0 +1,21 @@
+name: license-checks
+
+on:
+  push:
+
+jobs:
+  license-header-check:
+    name: license header check
+    runs-on: ubuntu-24.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+        path: ${{ github.event.repository.name }}
+    - name: Check license headers
+      uses: viperproject/check-license-header@v2
+      with:
+        path: "${{ github.event.repository.name }}"
+        config: "${{ github.event.repository.name }}/.github/license-checks/config.json"
+        strict: false

--- a/app/src/logger.c
+++ b/app/src/logger.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) 2024 The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/logger.h
+++ b/app/src/logger.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) 2024 The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) 2024 The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/radio_receiver.c
+++ b/app/src/radio_receiver.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) 2024 The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/radio_receiver.h
+++ b/app/src/radio_receiver.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) 2024 The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_packer.c
+++ b/app/src/telemetry_packer.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) 2024 The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_packer.h
+++ b/app/src/telemetry_packer.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) 2024 The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_sender.c
+++ b/app/src/telemetry_sender.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) 2024 The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_sender.h
+++ b/app/src/telemetry_sender.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024 - 2025 The efc developers.
+ * Copyright (c) 2024 The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/telemetry/mavlink/mavlink.c
+++ b/libs/telemetry/mavlink/mavlink.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) 2024-2025 The efc developers.
+ * Copyright (c) 2025 The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
This PR adds stage to GH actions to check if source files contain correct license headers.

DRAFT: Waiting on [#55](https://github.com/eurus-project/efc/pull/55) to be completed.