### PR TITLE
fix: Consolidate CMake versions across efc

### DIFF
--- a/libs/motor_control/esc/CMakeLists.txt
+++ b/libs/motor_control/esc/CMakeLists.txt
@@ -15,12 +15,12 @@
 # along with this program. If not, see <http://www.gnu.org/licenses/>.
 #
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.20.0)
 
 project (esc VERSION 1.0.0)
 
-set(SOURCES 
-    esc.c    
+set(SOURCES
+    esc.c
 )
 
 # Create the library


### PR DESCRIPTION
CMake >= 4.0 fails to build as it now requires cmake_minimum_required() version >= 3.5.0.
Zephyr and MAVLink satisfy this, and this is the only occurrence in our repository.

Even without new limitations it would be nice to keep consistent with stuff like this across non-external files.