### PR TITLE
Solve error code -116 in fs_mount on SD card

### DIFF
--- a/boards/eurus_project/eurus_nexus_v1_1/eurus_nexus_v1_1.dts
+++ b/boards/eurus_project/eurus_nexus_v1_1/eurus_nexus_v1_1.dts
@@ -189,7 +189,7 @@ stm32_lp_tick_source: &lptim4 {
 };
 
 &spi1 {
-    pinctrl-0 = <&spi1_nss_pa4 &spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
+    pinctrl-0 = <&spi1_sck_pa5 &spi1_miso_pa6 &spi1_mosi_pa7>;
 	pinctrl-names = "default";
     status = "okay";
     cs-gpios = <&gpioa 4 (GPIO_ACTIVE_LOW | GPIO_PULL_UP)>;


### PR DESCRIPTION
The error code -116 is returned in scenarios where the SD card does not respond.

The issue lies in a conflict between NSS_CS and CS defined as a simple GPIO. The NSS pin has been defined in the pinctrl-0 field at the same time as the CS GPIO has been defined in cs-gpios.

The problem is resolved by removing NSS_CS from the pinctrl-0 field.