### PR TITLE
CI: Fix creation year being hardcoded in license check

### DIFF
--- a/.github/workflows/license-checks.yml
+++ b/.github/workflows/license-checks.yml
@@ -10,6 +10,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
+        fetch-depth: 0
         submodules: recursive
 
     - name: Check license headers

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/app/src/logger.c
+++ b/app/src/logger.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/logger.h
+++ b/app/src/logger.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/main.c
+++ b/app/src/main.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/nvs_ids.h
+++ b/app/src/nvs_ids.h
@@ -1,9 +1,6 @@
-#ifndef NVS_IDS_H
-#define NVS_IDS_H
-
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -17,6 +14,9 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+
+#ifndef NVS_IDS_H
+#define NVS_IDS_H
 
 #define NVS_BOOT_COUNT_ID 1
 

--- a/app/src/radio_receiver.c
+++ b/app/src/radio_receiver.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/radio_receiver.h
+++ b/app/src/radio_receiver.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_packer.c
+++ b/app/src/telemetry_packer.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_packer.h
+++ b/app/src/telemetry_packer.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_sender.c
+++ b/app/src/telemetry_sender.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/telemetry_sender.h
+++ b/app/src/telemetry_sender.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/app/src/types.h
+++ b/app/src/types.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/demos/esc/CMakeLists.txt
+++ b/demos/esc/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/demos/esc/src/main.c
+++ b/demos/esc/src/main.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/demos/nvs-spi-flash/CMakeLists.txt
+++ b/demos/nvs-spi-flash/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/demos/nvs-spi-flash/src/main.c
+++ b/demos/nvs-spi-flash/src/main.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/CMakeLists.txt
+++ b/libs/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/logging/CMakeLists.txt
+++ b/libs/logging/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/logging/ulog/CMakeLists.txt
+++ b/libs/logging/ulog/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/logging/ulog/ulog.c
+++ b/libs/logging/ulog/ulog.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/logging/ulog/ulog.h
+++ b/libs/logging/ulog/ulog.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/motor_control/CMakeLists.txt
+++ b/libs/motor_control/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/motor_control/esc/CMakeLists.txt
+++ b/libs/motor_control/esc/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/motor_control/esc/esc.c
+++ b/libs/motor_control/esc/esc.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/motor_control/esc/esc.h
+++ b/libs/motor_control/esc/esc.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/telemetry/CMakeLists.txt
+++ b/libs/telemetry/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/telemetry/mavlink/CMakeLists.txt
+++ b/libs/telemetry/mavlink/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2025 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/libs/telemetry/mavlink/include/mavlink_custom.h
+++ b/libs/telemetry/mavlink/include/mavlink_custom.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2026 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/libs/telemetry/mavlink/mavlink.c
+++ b/libs/telemetry/mavlink/mavlink.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2025 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/licenserc.toml
+++ b/licenserc.toml
@@ -2,7 +2,7 @@ baseDir = "."
 
 inlineHeader = """
 This file is part of the efc project <https://github.com/eurus-project/efc/>.
-Copyright (c) ({{props.inceptionYear}} - Present), {{props.copyrightOwner}}.
+Copyright (c) ({{attrs.git_file_created_year}} - Present), {{props.copyrightOwner}}.
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -44,10 +44,8 @@ useDefaultMapping = true
 additionalHeaders = []
 
 [properties]
-inceptionYear = 2024
 copyrightOwner = "The efc developers"
 
 [git]
 ignore = 'auto'
-attrs = 'disable'
-
+attrs = 'enable'

--- a/sitl/CMakeLists.txt
+++ b/sitl/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2026 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/sitl/app/CMakeLists.txt
+++ b/sitl/app/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2026 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/sitl/app/src/main.c
+++ b/sitl/app/src/main.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2026 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/sitl/external/autopilot/CMakeLists.txt
+++ b/sitl/external/autopilot/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2026 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/sitl/external/mavlink/CMakeLists.txt
+++ b/sitl/external/mavlink/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This file is part of the efc project <https://github.com/eurus-project/efc/>.
-# Copyright (c) (2024 - Present), The efc developers.
+# Copyright (c) (2026 - Present), The efc developers.
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/sitl/external/mavlink/include/mavlink_custom.h
+++ b/sitl/external/mavlink/include/mavlink_custom.h
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2026 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/sitl/external/mavlink/mavlink.c
+++ b/sitl/external/mavlink/mavlink.c
@@ -1,6 +1,6 @@
 /*
  * This file is part of the efc project <https://github.com/eurus-project/efc/>.
- * Copyright (c) (2024 - Present), The efc developers.
+ * Copyright (c) (2026 - Present), The efc developers.
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by


### PR DESCRIPTION
Use `{{attrs.git_file_created_year}}` from [Hawkeye](https://github.com/korandoru/hawkeye) to automatically derive the file creation year from Git history for license header check.

This change removes the need to hardcode an inception year in `licenserc.toml` and ensures that license headers reflect the actual year each file was first committed.