### PR TITLE
Fix requirements.txt for lxml

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 future==1.0.0
 Jinja2==3.1.4
-lxml==5.3.0
+lxml==6.0.2
 MarkupSafe==3.0.2
 PyYAML==6.0.2


### PR DESCRIPTION
This PR fixes:

- lxml 5.3.0 fails to build with Python 3.14 and libxml2 2.15.x.

Upgrade to 6.0.2, which includes the required compatibility fixes.